### PR TITLE
Added caching for maven surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -706,6 +706,41 @@
             </execution>
           </executions>
         </plugin>
+
+        <plugin>
+          <groupId>com.gradle</groupId>
+          <artifactId>gradle-enterprise-maven-extension</artifactId>
+          <configuration>
+            <gradleEnterprise>
+              <normalization>
+                <runtimeClassPath>
+                  <propertiesNormalizations>
+                    <propertiesNormalization>
+                      <path>**/git.properties</path>
+                      <ignoredProperties>
+                        <ignore>git.build.time</ignore>
+                      </ignoredProperties>
+                    </propertiesNormalization>
+                  </propertiesNormalizations>
+                </runtimeClassPath>
+              </normalization>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <outputs>
+                    <directories>
+                      <directory>
+                        <name>junit.platform.listeners.uid.tracking.output.dir</name>
+                        <path>${project.basedir}/target/test-ids</path>
+                      </directory>
+                    </directories>
+                  </outputs>
+                </plugin>
+              </plugins>
+            </gradleEnterprise>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Added configuratin for caching the maven surefire plugin with `junit.platform.listeners.uid.tracking.output.dir` system property added as an output.

Scans:
- [Before](https://ge.solutions-team.gradle.com/s/ondwhmznpodxs/timeline?details=tqcooujjn6upg&goal-execution=suref)
- [After](https://ge.solutions-team.gradle.com/s/fjuuh2gf6teqs/timeline?details=tqcooujjn6upg)

Note: the `**/git.properties` property normalization is needed and was added in exp1 already.